### PR TITLE
Add watch mode and prevent browser caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "compile": "webpack --progress",
-    "serve": "http-server"
+    "watch": "webpack --progress --watch",
+    "serve": "http-server -c-1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A watch mode is always nice, and without disabling caching a hard reload is required after every change.